### PR TITLE
chore: [CAR-4527] updated awesome phonenumber version to support new area code

### DIFF
--- a/packages/phones/package.json
+++ b/packages/phones/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@superdispatch/ui": "^0.21.14",
-    "awesome-phonenumber": "^2.70.0",
+    "awesome-phonenumber": "3.4.0",
     "clsx": "^1.1.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5536,10 +5536,10 @@ autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-awesome-phonenumber@^2.70.0:
-  version "2.72.0"
-  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-2.72.0.tgz#5a07118c851bc398c6c5d85a7e11b2cc4d75f1b6"
-  integrity sha512-ygKfOnTnK5VBuU4XsMDom40ordTobsaAn9lQT2AefzmrbEZssh4PgP9/DAAnA25WbC1gL+LtGpns/iffYgewHg==
+awesome-phonenumber@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-3.4.0.tgz#e9a36a9add9e1a77a6a56b46b04d8b5ba0885110"
+  integrity sha512-lfkTwvuF2nYG9mmHXF7vMGVMJwM5kAnfRj98+RKrMR0TsaK24mSJMZXJgO+EtSoyX1ayVgot7Re4a6cLIikisQ==
 
 aws-sdk@^2.840.0:
   version "2.1051.0"


### PR DESCRIPTION
Issue Link:
https://superdispatch.atlassian.net/browse/CAR-4527

What is changed?
Updated awesome-phonenumber library from `2.70.0` to `3.4.0` to support new area codes in US, for example `656`

![image](https://github.com/superdispatch/web-ui/assets/118124821/80c769e6-0466-48de-bddb-b1e6d363cdce)
