### PR TITLE
fix(forms): Support nested fields for FormikMaxLengthTextField.

### DIFF
--- a/packages/forms/src/text/FormikMaxLengthTextField.spec.tsx
+++ b/packages/forms/src/text/FormikMaxLengthTextField.spec.tsx
@@ -37,27 +37,3 @@ test('changes', async () => {
 
   expect(view.onSubmit).toHaveBeenLastCalledWith({ name: 'John' });
 });
-
-test('changes for nested fields', () => {
-  const onBlur = jest.fn();
-  const onChange = jest.fn();
-
-  renderFormField(
-    <FormikMaxLengthTextField
-      label="Name"
-      name="user.name"
-      maxLength={100}
-      onBlur={onBlur}
-      onChange={onChange}
-    />,
-    { initialValues: { name: '' } },
-  );
-
-  const input = screen.getByLabelText('Name0 of 100');
-
-  userEvent.type(input, 'John');
-  userEvent.tab();
-
-  expect(input).toHaveValue('John');
-  expect(screen.getByLabelText('Name4 of 100')).toBeInTheDocument();
-});

--- a/packages/forms/src/text/FormikMaxLengthTextField.spec.tsx
+++ b/packages/forms/src/text/FormikMaxLengthTextField.spec.tsx
@@ -42,7 +42,7 @@ test('changes for nested fields', () => {
   const onBlur = jest.fn();
   const onChange = jest.fn();
 
-  const view = renderFormField(
+  renderFormField(
     <FormikMaxLengthTextField
       label="Name"
       name="user.name"

--- a/packages/forms/src/text/FormikMaxLengthTextField.spec.tsx
+++ b/packages/forms/src/text/FormikMaxLengthTextField.spec.tsx
@@ -37,3 +37,27 @@ test('changes', async () => {
 
   expect(view.onSubmit).toHaveBeenLastCalledWith({ name: 'John' });
 });
+
+test('changes for nested fields', () => {
+  const onBlur = jest.fn();
+  const onChange = jest.fn();
+
+  const view = renderFormField(
+    <FormikMaxLengthTextField
+      label="Name"
+      name="user.name"
+      maxLength={100}
+      onBlur={onBlur}
+      onChange={onChange}
+    />,
+    { initialValues: { name: '' } },
+  );
+
+  const input = screen.getByLabelText('Name0 of 100');
+
+  userEvent.type(input, 'John');
+  userEvent.tab();
+
+  expect(input).toHaveValue('John');
+  expect(screen.getByLabelText('Name4 of 100')).toBeInTheDocument();
+});

--- a/packages/forms/src/text/FormikMaxLengthTextField.tsx
+++ b/packages/forms/src/text/FormikMaxLengthTextField.tsx
@@ -14,11 +14,11 @@ export const FormikMaxLengthTextField: ForwardRefExoticComponent<Props> =
     const text = useMemo(() => {
       const value = getIn(values, name) as unknown;
 
-      if (!value) {
+      if (!value || typeof value !== 'string') {
         return '';
       }
 
-      return String(value);
+      return value;
     }, [values, name]);
 
     return (

--- a/packages/forms/src/text/FormikMaxLengthTextField.tsx
+++ b/packages/forms/src/text/FormikMaxLengthTextField.tsx
@@ -1,7 +1,7 @@
 import { Column, Columns } from '@superdispatch/ui';
 import { TextBox } from '@superdispatch/ui-lab';
-import { useFormikContext } from 'formik';
-import { forwardRef, ForwardRefExoticComponent } from 'react';
+import { getIn, useFormikContext } from 'formik';
+import { forwardRef, ForwardRefExoticComponent, useMemo } from 'react';
 import { FormikTextField, FormikTextFieldProps } from './FormikTextField';
 
 interface Props extends FormikTextFieldProps {
@@ -10,7 +10,16 @@ interface Props extends FormikTextFieldProps {
 
 export const FormikMaxLengthTextField: ForwardRefExoticComponent<Props> =
   forwardRef(({ name, label, maxLength, inputProps, ...props }, ref) => {
-    const { values } = useFormikContext<Record<string, string>>();
+    const { values } = useFormikContext<unknown>();
+    const text = useMemo(() => {
+      const value = getIn(values, name) as unknown;
+
+      if (!value) {
+        return '';
+      }
+
+      return String(value);
+    }, [values, name]);
 
     return (
       <FormikTextField
@@ -25,7 +34,7 @@ export const FormikMaxLengthTextField: ForwardRefExoticComponent<Props> =
             {maxLength != null && (
               <Column width="content">
                 <TextBox color="secondary">
-                  {values[name]?.length || 0} of {maxLength}
+                  {text.length} of {maxLength}
                 </TextBox>
               </Column>
             )}


### PR DESCRIPTION
**PR description:**

Support nested fields for FormikMaxLengthTextField.

**Checklist:**

- [x] I ran this code locally
- [x] I wrote the necessary tests
- [x]  My code follows the [style guidelines](http://bit.ly/sd-web-style-guide)
- [x] I followed the [instructions](http://bit.ly/sd-web-pr) to create a pull request

**Should know about:**

<!-- Is there anything else that should be known? -->
<!-- Any deployment notes? -->
<!-- Any additional documentation? -->
