### PR TITLE
fix: [FRONT-89] Tooltip color change

### DIFF
--- a/packages/ui/src/info-tooltip/__tests__/InfoTooltip.spec.tsx
+++ b/packages/ui/src/info-tooltip/__tests__/InfoTooltip.spec.tsx
@@ -77,7 +77,7 @@ it('checks component css InfoTooltip', () => {
       font-weight: 400;
       line-height: 20px;
       border-radius: 4px;
-      background-color: Color.Dark400;
+      background-color: Color.Dark500;
     }
 
     @media (min-width: 0px) and (max-width: 599.95px) {
@@ -93,7 +93,7 @@ it('checks component css InfoTooltip', () => {
     }
 
     .MuiTooltip-arrow {
-      color: Color.Dark400;
+      color: Color.Dark500;
       width: 1em;
       height: 0.71em;
       overflow: hidden;

--- a/packages/ui/src/tooltip/TooltipOverrides.ts
+++ b/packages/ui/src/tooltip/TooltipOverrides.ts
@@ -8,7 +8,7 @@ export function overrideTooltip(theme: SuperDispatchTheme): void {
     tooltip: {
       ...theme.typography.body2,
       padding: theme.spacing(1, 1.5),
-      backgroundColor: Color.Dark400,
+      backgroundColor: Color.Dark500,
     },
 
     popperArrow: {
@@ -27,7 +27,7 @@ export function overrideTooltip(theme: SuperDispatchTheme): void {
     },
 
     arrow: {
-      color: Color.Dark400,
+      color: Color.Dark500,
       fontSize: theme.spacing(1),
     },
   };

--- a/packages/ui/src/tooltip/__tests__/Tooltip.spec.tsx
+++ b/packages/ui/src/tooltip/__tests__/Tooltip.spec.tsx
@@ -93,7 +93,7 @@ it('checks component css', () => {
       font-weight: 400;
       line-height: 20px;
       border-radius: 4px;
-      background-color: Color.Dark400;
+      background-color: Color.Dark500;
     }
 
     @media (min-width: 0px) and (max-width: 599.95px) {
@@ -109,7 +109,7 @@ it('checks component css', () => {
     }
 
     .MuiTooltip-arrow {
-      color: Color.Dark400;
+      color: Color.Dark500;
       width: 1em;
       height: 0.71em;
       overflow: hidden;


### PR DESCRIPTION
**PR description:**

<!-- What is new? -->

**Implemented:**

<!-- What has changed? -->
Tooltip background color change from Dark400 to Dark500

**Checklist:**

- [x] I ran this code locally
- [x] I wrote the necessary tests
- [x] My code follows the [style guidelines](http://bit.ly/sd-web-style-guide)
- [x] I followed the [instructions](http://bit.ly/sd-web-pr) to create a pull request

**JIRA card:**

<!--ISSUE_LINK-->
https://superdispatch.atlassian.net/browse/FRONT-89

**Should know about:**

<!-- Is there anything else that should be known? -->
<!-- Any deployment notes? -->
<!-- Any additional documentation? -->
<img width="516" alt="image" src="https://github.com/superdispatch/web-ui/assets/118124821/4330b2b5-6688-4dc9-9564-8d0c42c0d237">

