### PR TITLE
revert: [FRONT-109] Reverted InputField padding space

### DIFF
--- a/packages/ui/src/text-field/TextFieldOverrides.tsx
+++ b/packages/ui/src/text-field/TextFieldOverrides.tsx
@@ -62,10 +62,9 @@ export function overrideTextField(theme: SuperDispatchTheme): void {
 
       '&.MuiInputBase-input': {
         fontSize: theme.spacing(1.75),
-        padding: theme.spacing(0.75, 1),
       },
 
-      height: theme.spacing(2.5),
+      height: theme.spacing(3),
       [sm]: { height: theme.spacing(2.5) },
     },
     inputMultiline: { resize: 'vertical' },
@@ -99,7 +98,7 @@ export function overrideTextField(theme: SuperDispatchTheme): void {
 
     input: {
       padding: theme.spacing(1.25, 1.5),
-      [sm]: { padding: theme.spacing(0.75, 1) },
+      [sm]: { padding: theme.spacing(1.25, 1.5) },
     },
 
     multiline: { padding: theme.spacing(0.75, 1) },

--- a/packages/ui/src/text-field/__tests__/TextField.spec.tsx
+++ b/packages/ui/src/text-field/__tests__/TextField.spec.tsx
@@ -291,7 +291,7 @@ it('checks component css', () => {
       color: currentColor;
       width: 100%;
       border: 0;
-      height: 20px;
+      height: 24px;
       margin: 0;
       display: block;
       padding: 6px 0 7px;
@@ -351,7 +351,6 @@ it('checks component css', () => {
     }
 
     .MuiInputBase-input.MuiInputBase-input {
-      padding: 6px 8px;
       font-size: 14px;
     }
 
@@ -524,7 +523,7 @@ it('checks component css', () => {
 
     @media (min-width: 600px) {
       .MuiOutlinedInput-input {
-        padding: 6px 8px;
+        padding: 10px 12px;
       }
     }
 


### PR DESCRIPTION
**PR description:**

<!-- What is new? -->

**Implemented:**

<!-- What has changed? -->
InputField padding reverted

**Checklist:**

- [ ] I ran this code locally
- [ ] I wrote the necessary tests
- [ ] My code follows the [style guidelines](http://bit.ly/sd-web-style-guide)
- [ ] I followed the [instructions](http://bit.ly/sd-web-pr) to create a pull request

**JIRA card:**

<!--ISSUE_LINK-->
https://superdispatch.atlassian.net/browse/FRONT-109

**Should know about:**

<!-- Is there anything else that should be known? -->
<!-- Any deployment notes? -->
<!-- Any additional documentation? -->
<img width="1106" alt="image" src="https://github.com/superdispatch/web-ui/assets/118124821/dd0760fe-be4b-4f25-9809-84dc962e232e">

