### PR TITLE
chore: [FRONT-97] Dialog component padding space updated

### DIFF
--- a/packages/ui/src/dialog/DialogOverrides.ts
+++ b/packages/ui/src/dialog/DialogOverrides.ts
@@ -30,7 +30,12 @@ export function overrideDialog(theme: SuperDispatchTheme): void {
   };
 
   theme.overrides.MuiDialogActions = {
-    root: { padding: theme.spacing(3) },
+    root: {
+      paddingBottom: theme.spacing(2),
+      paddingTop: theme.spacing(4),
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(3),
+    },
 
     spacing: {
       '& > :not(:first-child)': { marginLeft: theme.spacing(2) },

--- a/packages/ui/src/dialog/__tests__/Dialog.spec.tsx
+++ b/packages/ui/src/dialog/__tests__/Dialog.spec.tsx
@@ -173,8 +173,12 @@ it('checks component css', () => {
     .MuiDialogActions-root {
       flex: 0 0 auto;
       display: flex;
-      padding: 24px;
+      padding: 8px;
       align-items: center;
+      padding-top: 32px;
+      padding-left: 24px;
+      padding-right: 24px;
+      padding-bottom: 16px;
       justify-content: flex-end;
     }
 


### PR DESCRIPTION
**PR description:**

<!-- What is new? -->

**Implemented:**

<!-- What has changed? -->
Dialog Component DialogActions padding space change

**Checklist:**

- [x] I ran this code locally
- [x] I wrote the necessary tests
- [x] My code follows the [style guidelines](http://bit.ly/sd-web-style-guide)
- [x] I followed the [instructions](http://bit.ly/sd-web-pr) to create a pull request

**JIRA card:**

<!--ISSUE_LINK-->
https://superdispatch.atlassian.net/browse/FRONT-97

**Should know about:**

<!-- Is there anything else that should be known? -->
<!-- Any deployment notes? -->
<!-- Any additional documentation? -->
<img width="1261" alt="image" src="https://github.com/superdispatch/web-ui/assets/118124821/0347a075-8332-4ce5-9da3-42864694b0d6">

