### PR TITLE
Fixed default 'luxon' locale + added FormattedDate story

### DIFF
--- a/packages/dates/src/date-config/DateConfig.tsx
+++ b/packages/dates/src/date-config/DateConfig.tsx
@@ -7,6 +7,8 @@ import {
   useMemo,
 } from 'react';
 
+Settings.defaultLocale = 'en-US';
+
 export function setDefaultTimeZone(offset: number | 'local'): string {
   if (offset === 'local') {
     Settings.defaultZoneName = offset;

--- a/packages/dates/src/formatted-date/FormattedDate.stories.tsx
+++ b/packages/dates/src/formatted-date/FormattedDate.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta } from '@storybook/react';
+import { FormattedDate } from './FormattedDate';
+
+export default {
+  title: 'Dates/FormattedDate',
+  component: FormattedDate,
+} as Meta;
+
+const newDate = () => new Date();
+
+export const Default = () => <FormattedDate date={newDate()} variant="Date" />;
+
+export const ShortDate = () => (
+  <FormattedDate date={newDate()} variant="ShortDate" />
+);
+
+export const Time = () => <FormattedDate date={newDate()} variant="Time" />;
+
+export const DateTime = () => (
+  <FormattedDate date={newDate()} variant="DateTime" />
+);
+
+export const WithFallback = () => (
+  <FormattedDate date={null} fallback="No date provided" variant="Date" />
+);


### PR DESCRIPTION
**PR description:**

Appeared an issue with dates in Russian
<img width="1022" alt="Screenshot 2023-12-06 at 02 38 51" src="https://github.com/superdispatch/web-ui/assets/2178637/1a53c178-a095-4172-a6ab-842af66a72bd">

**Implemented:**

Now luxon locale is always 'en-US'

**Checklist:**

- [x] I ran this code locally
- [ ] I wrote the necessary tests
- [x] My code follows the [style guidelines](http://bit.ly/sd-web-style-guide)
- [x] I followed the [instructions](http://bit.ly/sd-web-pr) to create a pull request

**JIRA card:**

[Slack thread
](https://superdispatch.slack.com/archives/CC7AY7LL8/p1701764912520969)