### PR TITLE
feat: [LM-1580] improve selecting by search for FormikTextField

### DIFF
--- a/packages/forms/src/text/utils.ts
+++ b/packages/forms/src/text/utils.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import {
   Children,
   Fragment,
@@ -25,7 +26,9 @@ export function getOptionsFromChildren(
     )
     .map((child) => ({
       value: child.props.value,
-      label: child.props.children?.toString() || '',
+      label: isValidElement(child.props.children)
+        ? String(get(child.props.children.props, 'children') || '')
+        : String(child.props.children || ''),
     }));
 }
 


### PR DESCRIPTION
**PR description:**
Ordinary case: 
`<MenuItem value='abc'>ABC</MenuItem>`

This PR handles cases like these:
`<MenuItem value='abc'><Typography>ABC</Typography></MenuItem>`
`<MenuItem value='abc'><Tag ...>ABC</Tag></MenuItem>`

<!-- What is new? -->

**Implemented:**

<!-- What has changed? -->

**Checklist:**

- [x] I ran this code locally
- [ ] I wrote the necessary tests
- [x] My code follows the [style guidelines](http://bit.ly/sd-web-style-guide)
- [x] I followed the [instructions](http://bit.ly/sd-web-pr) to create a pull request

**JIRA card:**

<!--ISSUE_LINK-->

**Should know about:**

<!-- Is there anything else that should be known? -->
<!-- Any deployment notes? -->
<!-- Any additional documentation? -->
